### PR TITLE
feat: add favorite and dismiss functionality to screening results

### DIFF
--- a/src/components/NotesEditDialog.tsx
+++ b/src/components/NotesEditDialog.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useAddNoteToScreeningResult } from '@/hooks/useScreeningResults';
+
+interface NotesEditDialogProps {
+  isOpen: boolean;
+  onClose: () => void;
+  resultId: string;
+  currentNotes?: string;
+  candidateName: string;
+}
+
+const NotesEditDialog: React.FC<NotesEditDialogProps> = ({
+  isOpen,
+  onClose,
+  resultId,
+  currentNotes = '',
+  candidateName
+}) => {
+  const [notes, setNotes] = useState('');
+  const addNoteMutation = useAddNoteToScreeningResult();
+
+  // Update notes when dialog opens or currentNotes changes
+  useEffect(() => {
+    if (isOpen) {
+      setNotes(currentNotes);
+    }
+  }, [isOpen, currentNotes]);
+
+  const handleSave = async () => {
+    try {
+      await addNoteMutation.mutateAsync({
+        id: resultId,
+        notes: notes.trim()
+      });
+      onClose();
+    } catch (error) {
+      // Error handling is done in the mutation hook
+      console.error('Failed to save notes:', error);
+    }
+  };
+
+  const handleCancel = () => {
+    setNotes(currentNotes); // Reset to original value
+    onClose();
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="sm:max-w-[600px]">
+        <DialogHeader>
+          <DialogTitle>Edit Notes for {candidateName}</DialogTitle>
+          <DialogDescription>
+            Add or edit your notes about this candidate. These notes will be visible to your team.
+          </DialogDescription>
+        </DialogHeader>
+        
+        <div className="space-y-4 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="notes">Notes</Label>
+            <Textarea
+              id="notes"
+              placeholder="Enter your notes about this candidate..."
+              value={notes}
+              onChange={(e) => setNotes(e.target.value)}
+              className="min-h-[120px] resize-none"
+              disabled={addNoteMutation.isPending}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={handleCancel}
+            disabled={addNoteMutation.isPending}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={addNoteMutation.isPending}
+          >
+            {addNoteMutation.isPending ? 'Saving...' : 'Save Notes'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default NotesEditDialog;

--- a/src/components/ScreeningResultActions.tsx
+++ b/src/components/ScreeningResultActions.tsx
@@ -6,12 +6,15 @@ import {
   ExternalLink,
   ChevronDown,
   ChevronUp,
-  Eye
+  Eye,
+  Star,
+  X
 } from 'lucide-react';
 import { supabase } from '@/integrations/supabase/client';
 import { useNavigate } from 'react-router-dom';
 import { useToast } from '@/hooks/use-toast';
 import { VoiceInterviewService } from '@/services/voiceInterviewService';
+import { useUpdateFavoriteStatus, useUpdateDismissStatus } from '@/hooks/useScreeningResults';
 import {
   AlertDialog,
   AlertDialogAction,
@@ -33,6 +36,8 @@ interface ScreeningResultActionsProps {
   onRequestVoiceScreening: () => void;
   onToggleExpansion: () => void;
   showViewDetails?: boolean; // Optional prop to show/hide view details button
+  isFavorite?: boolean;      // Add favorite status
+  isDismissed?: boolean;     // Add dismiss status
 }
 
 const ScreeningResultActions: React.FC<ScreeningResultActionsProps> = ({
@@ -44,11 +49,17 @@ const ScreeningResultActions: React.FC<ScreeningResultActionsProps> = ({
   isExpanded,
   onRequestVoiceScreening,
   onToggleExpansion,
-  showViewDetails = true
+  showViewDetails = true,
+  isFavorite = false,
+  isDismissed = false
 }) => {
   const { toast } = useToast();
   const navigate = useNavigate();
   const [showConfirmDialog, setShowConfirmDialog] = useState(false);
+  
+  // Add mutation hooks
+  const updateFavoriteMutation = useUpdateFavoriteStatus();
+  const updateDismissMutation = useUpdateDismissStatus();
 
   return (
     <div className="flex flex-wrap items-center gap-3 w-full lg:w-96 lg:justify-end">
@@ -166,6 +177,48 @@ const ScreeningResultActions: React.FC<ScreeningResultActionsProps> = ({
           </Button>
         </div>
       )}
+
+      {/* Favorite Button - Responsive width */}
+      <div className="w-20 sm:w-24">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => updateFavoriteMutation.mutate({ 
+            id: resultId, 
+            is_favorite: !isFavorite 
+          })}
+          disabled={updateFavoriteMutation.isPending}
+          className={`flex items-center gap-2 text-xs sm:text-sm h-9 px-3 w-full ${
+            isFavorite 
+              ? 'border-yellow-300 text-yellow-600 hover:bg-yellow-50 bg-yellow-50' 
+              : 'border-yellow-300 text-yellow-600 hover:bg-yellow-50'
+          }`}
+        >
+          <Star className={`h-4 w-4 ${isFavorite ? 'fill-current' : ''}`} />
+          <span className="hidden xs:inline">{isFavorite ? 'Fav' : 'Star'}</span>
+        </Button>
+      </div>
+
+      {/* Dismiss Button - Responsive width */}
+      <div className="w-20 sm:w-24">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => updateDismissMutation.mutate({ 
+            id: resultId, 
+            is_dismissed: !isDismissed 
+          })}
+          disabled={updateDismissMutation.isPending}
+          className={`flex items-center gap-2 text-xs sm:text-sm h-9 px-3 w-full ${
+            isDismissed 
+              ? 'border-red-300 text-red-600 hover:bg-red-50 bg-red-50' 
+              : 'border-red-300 text-red-600 hover:bg-red-50'
+          }`}
+        >
+          <X className="h-4 w-4" />
+          <span className="hidden xs:inline">{isDismissed ? 'Restore' : 'Dismiss'}</span>
+        </Button>
+      </div>
       
       {/* Details Toggle - Responsive width */}
       <div className="w-16 sm:w-20 lg:w-24">

--- a/src/components/ScreeningResultAnalysis.tsx
+++ b/src/components/ScreeningResultAnalysis.tsx
@@ -1,10 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
 import { 
   TrendingUp,
   Mic,
-  StickyNote
+  StickyNote,
+  Edit3
 } from 'lucide-react';
+import NotesEditDialog from './NotesEditDialog';
 
 interface AnalysisSection {
   title: string;
@@ -23,6 +26,8 @@ interface ScreeningResultAnalysisProps {
   interviewCompletedAt?: string;
   voiceScreeningRequested?: boolean;
   notes?: string;
+  resultId?: string;
+  candidateName?: string;
 }
 
 const ScreeningResultAnalysis: React.FC<ScreeningResultAnalysisProps> = ({
@@ -34,8 +39,11 @@ const ScreeningResultAnalysis: React.FC<ScreeningResultAnalysisProps> = ({
   interviewSummary,
   interviewCompletedAt,
   voiceScreeningRequested,
-  notes
+  notes,
+  resultId,
+  candidateName
 }) => {
+  const [isNotesDialogOpen, setIsNotesDialogOpen] = useState(false);
   const getColorClasses = (color: string) => {
     switch (color) {
       case 'green':
@@ -141,12 +149,44 @@ const ScreeningResultAnalysis: React.FC<ScreeningResultAnalysisProps> = ({
         color: 'orange'
       })}
 
-      {notes && renderSection({
-        title: "Company Notes",
-        content: notes,
-        icon: <StickyNote className="h-4 w-4" />,
-        color: 'purple'
-      })}
+      {/* Company Notes Section with Edit Button */}
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <h4 className="font-semibold text-purple-700 flex items-center">
+            <StickyNote className="h-4 w-4 mr-2 text-purple-600" />
+            Company Notes
+          </h4>
+          {resultId && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setIsNotesDialogOpen(true)}
+              className="h-8 px-2 text-purple-600 hover:text-purple-700 hover:bg-purple-50"
+            >
+              <Edit3 className="h-3 w-3 mr-1" />
+              Edit
+            </Button>
+          )}
+        </div>
+        <div className="p-3 rounded-lg border text-purple-700 bg-purple-50 border-purple-200">
+          {notes ? (
+            <p className="text-sm text-gray-700 whitespace-pre-wrap">{notes}</p>
+          ) : (
+            <p className="text-sm text-gray-500 italic">No notes added yet. Click Edit to add notes about this candidate.</p>
+          )}
+        </div>
+      </div>
+
+      {/* Notes Edit Dialog */}
+      {resultId && candidateName && (
+        <NotesEditDialog
+          isOpen={isNotesDialogOpen}
+          onClose={() => setIsNotesDialogOpen(false)}
+          resultId={resultId}
+          currentNotes={notes || ''}
+          candidateName={candidateName}
+        />
+      )}
     </div>
   );
 };

--- a/src/components/ScreeningResultCard.tsx
+++ b/src/components/ScreeningResultCard.tsx
@@ -38,7 +38,13 @@ const ScreeningResultCard: React.FC<ScreeningResultCardProps> = ({
 
   return (
     <Card 
-      className="border-l-4 border-l-blue-500 shadow-sm hover:shadow-md transition-all duration-200 cursor-pointer hover:bg-gray-50"
+      className={`border-l-4 shadow-sm hover:shadow-md transition-all duration-200 cursor-pointer ${
+        result.is_dismissed 
+          ? 'border-l-red-500 bg-gray-50 opacity-75 hover:bg-gray-100' 
+          : result.is_favorite 
+            ? 'border-l-yellow-500 bg-yellow-50 hover:bg-yellow-100' 
+            : 'border-l-blue-500 hover:bg-gray-50'
+      }`}
       onClick={handleCardClick}
     >
       <CardHeader className="pb-6">
@@ -65,6 +71,8 @@ const ScreeningResultCard: React.FC<ScreeningResultCardProps> = ({
             onRequestVoiceScreening={() => onRequestVoiceScreening(result)}
             onToggleExpansion={() => onToggleExpansion(result.id)}
             showViewDetails={false}
+            isFavorite={result.is_favorite || false}
+            isDismissed={result.is_dismissed || false}
           />
         </div>
 
@@ -84,6 +92,8 @@ const ScreeningResultCard: React.FC<ScreeningResultCardProps> = ({
               interviewCompletedAt={result.interview_completed_at}
               voiceScreeningRequested={result.voice_screening_requested}
               notes={result.notes}
+              resultId={result.id}
+              candidateName={`${result.first_name} ${result.last_name}`}
             />
           </CardContent>
         </CollapsibleContent>

--- a/src/hooks/useScreeningResults.ts
+++ b/src/hooks/useScreeningResults.ts
@@ -26,6 +26,8 @@ export interface ScreeningResult {
   interview_summary?: string;
   interview_completed_at?: string;
   application_id?: string;  // Add application_id field
+  is_favorite?: boolean;    // Add favorite status
+  is_dismissed?: boolean;   // Add dismiss status
   // Job details from join
   job?: {
     id: string;
@@ -254,6 +256,88 @@ export const useUpdateCallStatus = () => {
       toast({
         title: "Error",
         description: "Failed to update call status. Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+};
+
+export const useUpdateFavoriteStatus = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ id, is_favorite }: { id: string; is_favorite: boolean }) => {
+      const { data, error } = await supabase
+        .from('screening_results')
+        .update({ 
+          is_favorite, 
+          updated_at: new Date().toISOString() 
+        })
+        .eq('id', id)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('Error updating favorite status:', error);
+        throw error;
+      }
+
+      return data as ScreeningResult;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['screening_results'] });
+      toast({
+        title: variables.is_favorite ? "Added to Favorites" : "Removed from Favorites",
+        description: `Candidate ${variables.is_favorite ? 'added to' : 'removed from'} favorites.`,
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to update favorite status:', error);
+      toast({
+        title: "Error",
+        description: "Failed to update favorite status. Please try again.",
+        variant: "destructive",
+      });
+    },
+  });
+};
+
+export const useUpdateDismissStatus = () => {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ id, is_dismissed }: { id: string; is_dismissed: boolean }) => {
+      const { data, error } = await supabase
+        .from('screening_results')
+        .update({ 
+          is_dismissed, 
+          updated_at: new Date().toISOString() 
+        })
+        .eq('id', id)
+        .select()
+        .single();
+
+      if (error) {
+        console.error('Error updating dismiss status:', error);
+        throw error;
+      }
+
+      return data as ScreeningResult;
+    },
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['screening_results'] });
+      toast({
+        title: variables.is_dismissed ? "Candidate Dismissed" : "Candidate Restored",
+        description: `Candidate ${variables.is_dismissed ? 'dismissed' : 'restored'} successfully.`,
+      });
+    },
+    onError: (error) => {
+      console.error('Failed to update dismiss status:', error);
+      toast({
+        title: "Error",
+        description: "Failed to update dismiss status. Please try again.",
         variant: "destructive",
       });
     },

--- a/src/pages/ScreeningResults.tsx
+++ b/src/pages/ScreeningResults.tsx
@@ -60,6 +60,7 @@ const ScreeningResults = () => {
   const [sortOrder, setSortOrder] = useState('desc');
   const [selectedJobId, setSelectedJobId] = useState<string>('all');
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
+  const [statusFilter, setStatusFilter] = useState('all'); // all, favorites, dismissed
   
   // State for notes
   const [noteDialogOpen, setNoteDialogOpen] = useState(false);
@@ -91,7 +92,11 @@ const ScreeningResults = () => {
         ? result.job_id === jobId 
         : selectedJobId === 'all' || result.job_id === selectedJobId;
 
-      return matchesSearch && matchesScore && matchesJob;
+      const matchesStatus = statusFilter === 'all' || 
+        (statusFilter === 'favorites' && result.is_favorite) ||
+        (statusFilter === 'dismissed' && result.is_dismissed);
+
+      return matchesSearch && matchesScore && matchesJob && matchesStatus;
     });
 
     // Sort results by score
@@ -107,7 +112,7 @@ const ScreeningResults = () => {
     });
 
     return filtered;
-  }, [screeningResults, searchTerm, scoreFilter, sortOrder, selectedJobId]);
+  }, [screeningResults, searchTerm, scoreFilter, sortOrder, selectedJobId, statusFilter, jobId]);
 
   // Redirect if not company user - THIS MUST BE AFTER ALL HOOKS
   React.useEffect(() => {
@@ -325,6 +330,21 @@ const ScreeningResults = () => {
                     <SelectContent>
                       <SelectItem value="desc">Highest First</SelectItem>
                       <SelectItem value="asc">Lowest First</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Status Filter - 20% of space (1/5 column) */}
+                <div className="col-span-1 lg:col-span-1 space-y-2">
+                  <Label htmlFor="status-filter">Status Filter</Label>
+                  <Select value={statusFilter} onValueChange={setStatusFilter}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="All candidates" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All Candidates</SelectItem>
+                      <SelectItem value="favorites">Favorites Only</SelectItem>
+                      <SelectItem value="dismissed">Dismissed Only</SelectItem>
                     </SelectContent>
                   </Select>
                 </div>

--- a/supabase/migrations/20250129000001_add_favorite_dismiss_to_screening_results.sql
+++ b/supabase/migrations/20250129000001_add_favorite_dismiss_to_screening_results.sql
@@ -1,0 +1,14 @@
+-- Add favorite and dismiss columns to screening_results table
+-- This allows hiring managers to mark candidates as favorites or dismissed
+
+ALTER TABLE public.screening_results 
+ADD COLUMN is_favorite BOOLEAN DEFAULT false,
+ADD COLUMN is_dismissed BOOLEAN DEFAULT false;
+
+-- Create indexes for better query performance on filtering
+CREATE INDEX idx_screening_results_is_favorite ON public.screening_results(is_favorite);
+CREATE INDEX idx_screening_results_is_dismissed ON public.screening_results(is_dismissed);
+
+-- Add comments to document the purpose
+COMMENT ON COLUMN public.screening_results.is_favorite IS 'Indicates if the candidate is marked as favorite by hiring manager';
+COMMENT ON COLUMN public.screening_results.is_dismissed IS 'Indicates if the candidate is dismissed by hiring manager';


### PR DESCRIPTION
- Implemented favorite and dismiss buttons in ScreeningResultActions for managing candidate status.
- Enhanced ScreeningResultCard and ScreeningResultDetail to display favorite and dismiss states.
- Added mutation hooks for updating favorite and dismiss statuses in useScreeningResults.
- Introduced a status filter in ScreeningResults to allow users to view favorites and dismissed candidates.
- Updated ScreeningResultAnalysis to include an edit button for company notes with a dialog for editing.